### PR TITLE
Sf verlauf fixes

### DIFF
--- a/src/charts/helperData.tsx
+++ b/src/charts/helperData.tsx
@@ -26,15 +26,15 @@ export const StudierendenVerlauf2020 = [
         meanSuccess: [1.0000, 0.9667, 0.9554, 0.9558, 0.8784, 1.0000, 0.9524, 1.0037],
         kohorten: [
             { 
-                kohorte: "WiSe15/16",
+                kohorte: "akademisches Jahr 2015",
                 netStudents: [10, 9, 9, 9, 7, 7, 6, 6],
             },
             {
-                kohorte: "WiSe16/17",
+                kohorte: "akademisches Jahr 2016",
                 netStudents: [21, 21, 19, 18, 17, 17, 17, 18],
             },
             {
-                kohorte: "WiSe17/18",
+                kohorte: "akademisches Jahr 2017",
                 netStudents: [26, 26, 25, 23, 21, 21, 21, 20],
             },
         ],

--- a/src/charts/helperData.tsx
+++ b/src/charts/helperData.tsx
@@ -28,14 +28,20 @@ export const StudierendenVerlauf2020 = [
             { 
                 kohorte: "akademisches Jahr 2015",
                 netStudents: [10, 9, 9, 9, 7, 7, 6, 6],
+                WiSe: [10, 9, 9, 9, 7, 7, 6, 6],
+                SoSe: [0, 0, 0, 0, 0, 0, 0, 0],
             },
             {
                 kohorte: "akademisches Jahr 2016",
                 netStudents: [21, 21, 19, 18, 17, 17, 17, 18],
+                WiSe: [21, 21, 19, 18, 17, 17, 17, 18],
+                SoSe: [0, 0, 0, 0, 0, 0, 0, 0],
             },
             {
                 kohorte: "akademisches Jahr 2017",
                 netStudents: [26, 26, 25, 23, 21, 21, 21, 20],
+                WiSe: [26, 26, 25, 23, 21, 21, 21, 20],
+                SoSe: [0, 0, 0, 0, 0, 0, 0, 0],
             },
         ],
     },

--- a/src/components/sfStudentsComponent.tsx
+++ b/src/components/sfStudentsComponent.tsx
@@ -81,6 +81,26 @@ const data = () => {
     };
 };
 
+function detailedTooltipLabel(context: any) {
+    // let label = context.dataset.label || '';
+    //only change bar tooltip labels
+    // if (context.dataset.type === 'bar') {
+    //     return label
+    // };
+    // let label = context.dataset.label || '';
+    //                 console.log(context);
+    //                 if (context.dataset.type === 'bar') {
+    //                     return 'akad. Jahr: ' + context.raw;
+    //                 };
+    //                 if (label) {
+    //                     label += ': ';
+    //                 };
+    //                 if (context.parsed.y !== null) {
+    //                     label += context.parsed.y;
+    //                 };
+    //                 return label;
+};
+
 const options = {
     scales: {
         x: {
@@ -121,9 +141,30 @@ const options = {
               weight: "normal" as any,
             }
         },
-        colors: {
-            //forceOverride: true,
-        },
+        // tooltip: {
+        //     callbacks: {
+        //         label: function(context: any) {
+        //             let label = context.dataset.label || '';
+        //             console.log(context);
+        //             if (context.dataset.type === 'bar') {
+        //                 return 'akad. Jahr: ' + context.raw;
+        //             };
+        //             if (label) {
+        //                 label += ': ';
+        //             };
+        //             if (context.parsed.y !== null) {
+        //                 label += context.parsed.y;
+        //             };
+        //             return label;
+        //         },
+        //         afterLabel: function(context: any) {
+        //             if (context.dataset.type === 'bar') {
+        //                 return 'Testtext';
+        //             };
+        //             return '';
+        //         },
+        //     },
+        // },
     },
 };
 


### PR DESCRIPTION
Currently only renaming the labels for the data in the `helperData` to confirm to fixes. Backend-API Calls needed for full split show (WiSe+SoSe data) in tooltip `onHover` Event but provided the necessary code as comments